### PR TITLE
feat: Add support to inject projected volume including audience in k8s sa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build:
 		.
 
 image: build
-	podman build --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) .
+	docker build --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) .
 
 # Deploys Vault dev server and a locally built Agent Injector.
 # Run multiple times to deploy new builds of the injector.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build:
 		.
 
 image: build
-	docker build --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) .
+	podman build --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) .
 
 # Deploys Vault dev server and a locally built Agent Injector.
 # Run multiple times to deploy new builds of the injector.

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -19,6 +19,7 @@ import (
 const (
 	DefaultVaultImage                       = "hashicorp/vault:1.16.1"
 	DefaultVaultAuthType                    = "kubernetes"
+	VaultAuthTypeJWT                        = "jwt"
 	DefaultVaultAuthPath                    = "auth/kubernetes"
 	DefaultAgentRunAsUser                   = 100
 	DefaultAgentRunAsGroup                  = 1000
@@ -199,6 +200,9 @@ type ServiceAccountTokenVolume struct {
 
 	// TokenPath to the JWT token within the volume
 	TokenPath string
+
+	// The Audience used when generating the JWT
+	Audience string
 }
 
 type Secret struct {
@@ -759,6 +763,14 @@ func (a *Agent) Validate() error {
 }
 
 func serviceaccount(pod *corev1.Pod) (*ServiceAccountTokenVolume, error) {
+	if audience := pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenAudience]; audience != "" {
+		return &ServiceAccountTokenVolume{
+			Name:      "token",
+			MountPath: DefaultServiceAccountMount,
+			TokenPath: "token",
+			Audience:  audience,
+		}, nil
+	}
 	if volumeName := pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenVolumeName]; volumeName != "" {
 		// Attempt to find existing mount point of named volume and copy mount path
 		for _, container := range pod.Spec.Containers {
@@ -897,4 +909,23 @@ func (a *Agent) copyVolumeMounts(targetContainerName string) []corev1.VolumeMoun
 		}
 	}
 	return copiedVolumeMounts
+}
+
+func (a *Agent) createProjectedVolumes() corev1.Volume {
+	if a.ServiceAccountTokenVolume.Audience != "" {
+		return corev1.Volume{
+			Name: a.ServiceAccountTokenVolume.Name,
+			VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Audience:          a.ServiceAccountTokenVolume.Audience,
+							ExpirationSeconds: pointer.Int64(3600),
+							Path:              a.ServiceAccountTokenVolume.TokenPath,
+						},
+					},
+				},
+			}}}
+	}
+	return corev1.Volume{}
 }

--- a/agent-inject/agent/agent.go
+++ b/agent-inject/agent/agent.go
@@ -19,7 +19,6 @@ import (
 const (
 	DefaultVaultImage                       = "hashicorp/vault:1.16.1"
 	DefaultVaultAuthType                    = "kubernetes"
-	VaultAuthTypeJWT                        = "jwt"
 	DefaultVaultAuthPath                    = "auth/kubernetes"
 	DefaultAgentRunAsUser                   = 100
 	DefaultAgentRunAsGroup                  = 1000

--- a/agent-inject/agent/agent_test.go
+++ b/agent-inject/agent/agent_test.go
@@ -564,6 +564,41 @@ func Test_serviceaccount(t *testing.T) {
 				},
 			},
 		},
+		"projected service account with audience": {
+			expected: &ServiceAccountTokenVolume{
+				Name:      "token",
+				MountPath: "/var/run/secrets/vault.hashicorp.com/serviceaccount",
+				TokenPath: "token",
+				Audience:  "audience",
+			},
+			expectedError: "",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"vault.hashicorp.com/vault-service-account-token-audience": "audience",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "token",
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{
+										{
+											ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+												Path:     "token",
+												Audience: "audience",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/agent-inject/agent/annotations.go
+++ b/agent-inject/agent/annotations.go
@@ -172,6 +172,9 @@ const (
 	// service account token
 	AnnotationAgentServiceAccountTokenVolumeName = "vault.hashicorp.com/agent-service-account-token-volume-name"
 
+	// AnnotationVaultAuthJWT specifies the jwt audience to use when requesting a token
+	AnnotationAgentServiceAccountTokenAudience = "vault.hashicorp.com/vault-service-account-token-audience"
+
 	// AnnotationVaultService is the name of the Vault server.  This can be overridden by the
 	// user but will be set by a flag on the deployment.
 	AnnotationVaultService = "vault.hashicorp.com/service"
@@ -463,6 +466,10 @@ func Init(pod *corev1.Pod, cfg AgentConfig) error {
 	}
 
 	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenVolumeName]; !ok {
+		pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenVolumeName] = ""
+	}
+
+	if _, ok := pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenAudience]; !ok {
 		pod.ObjectMeta.Annotations[AnnotationAgentServiceAccountTokenVolumeName] = ""
 	}
 

--- a/agent-inject/agent/container_volume.go
+++ b/agent-inject/agent/container_volume.go
@@ -93,6 +93,11 @@ func (a *Agent) ContainerTokenVolume() []corev1.Volume {
 		vols = append(vols, sidecarVol)
 	}
 
+	if a.ServiceAccountTokenVolume.Audience != "" {
+		v := a.createProjectedVolumes()
+		vols = append(vols, v)
+	}
+
 	return vols
 }
 


### PR DESCRIPTION
This is a very rough PR that adds support for defining an "audience" when mounting the kubernetes SA.

Example Spec:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: debug
  name: debug
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: debug
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: debug
      annotations:
        vault.hashicorp.com/agent-inject: 'true'
        vault.hashicorp.com/auth-type: jwt
        vault.hashicorp.com/vault-service-account-token-audience: "audience"
        vault.hashicorp.com/auth-config-path: /var/run/secrets/vault.hashicorp.com/serviceaccount/token
        vault.hashicorp.com/auth-path: auth/kube/kind/kind
        vault.hashicorp.com/auth-config-role: vault-agent
        vault.hashicorp.com/auth-config-remove_jwt_after_reading: 'false'
        vault.hashicorp.com/agent-inject-template-creds: |
          {{- with secret "secrets/groups/kind/creds" -}}
          {{ .Data.data.username }}:{{ .Data.data.password}}
          {{ end }}
    spec:
      serviceAccountName: vault-agent-sa
      containers:
      - image: ubuntu
        name: ubuntu
        resources: {}
        command: ["/usr/bin/sleep","3600"]
```

This adds a volume a volume mount to only the vault-agent-init and vault-agent sidecar containers:
```
    volumeMounts:
    - mountPath: /var/run/secrets/vault.hashicorp.com/serviceaccount
      name: token
      readOnly: true

volumes:
  - name: token
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          audience: "audience"
          expirationSeconds: 3600
          path: token
```